### PR TITLE
fix: unicorn sandbox rendering

### DIFF
--- a/packages/ranch_components/sandbox/lib/common/common.dart
+++ b/packages/ranch_components/sandbox/lib/common/common.dart
@@ -1,1 +1,2 @@
+export 'game_property.dart';
 export 'story_game.dart';

--- a/packages/ranch_components/sandbox/lib/common/game_property.dart
+++ b/packages/ranch_components/sandbox/lib/common/game_property.dart
@@ -1,0 +1,30 @@
+import 'package:dashbook/dashbook.dart';
+import 'package:flame/components.dart';
+import 'package:sandbox/common/story_game.dart';
+
+/// A dashbook's [Property] that keeps a [StoryGame] in the [DashbookContext].
+class GameProperty extends Property<StoryGame> {
+  GameProperty(StoryGame game) : super('game', game);
+}
+
+/// Adds [storyGame] to [DashbookContext]
+extension DashbookContextX on DashbookContext {
+  /// Keeps an instance of [StoryGame] game alive across builds.
+  StoryGame storyGame({
+    required PositionComponent component,
+    bool center = true,
+  }) {
+    final existingProperty = properties['game'];
+
+    if (existingProperty is GameProperty) {
+      final game = existingProperty.getValue();
+      if (component != game.component) {
+        game.setComponent(component);
+      }
+      return game;
+    }
+
+    final property = properties['game'] = GameProperty(StoryGame(component));
+    return property.getValue();
+  }
+}

--- a/packages/ranch_components/sandbox/lib/common/story_game.dart
+++ b/packages/ranch_components/sandbox/lib/common/story_game.dart
@@ -5,7 +5,7 @@ import 'package:flame/game.dart';
 
 class StoryGame extends FlameGame {
   StoryGame(
-    this.component, {
+    this._component, {
     this.center = true,
   }) {
     // Clearing the prefix allows us to load images from packages.
@@ -13,7 +13,16 @@ class StoryGame extends FlameGame {
     Flame.images.prefix = '';
   }
 
-  final PositionComponent component;
+  PositionComponent _component;
+
+  PositionComponent get component => _component;
+
+  Future<void> setComponent(PositionComponent value) async {
+    _component.removeFromParent();
+    value.removeFromParent();
+    return add(_component = value);
+  }
+
   final bool center;
 
   @override
@@ -24,6 +33,6 @@ class StoryGame extends FlameGame {
     if (center) {
       camera.followVector2(Vector2.zero());
     }
-    await add(component);
+    await add(_component);
   }
 }

--- a/packages/ranch_components/sandbox/lib/stories/unicorn_component/stories.dart
+++ b/packages/ranch_components/sandbox/lib/stories/unicorn_component/stories.dart
@@ -5,46 +5,30 @@ import 'package:sandbox/common/common.dart';
 
 void addUnicornComponentStories(Dashbook dashbook) {
   dashbook.storiesOf('UnicornComponent').add(
-    'idle',
+    'Playground',
     (context) {
+      final defaultUnicorn = BabyUnicornComponent();
       final unicorn = context.listProperty<UnicornComponent>(
         'Unicorn stage',
-        BabyUnicornComponent(),
+        defaultUnicorn,
         [
-          BabyUnicornComponent(),
+          defaultUnicorn,
           ChildUnicornComponent(),
           TeenUnicornComponent(),
           AdultUnicornComponent(),
         ],
       );
+      final unicornState = context.listProperty<UnicornState>(
+        'Unicorn state',
+        UnicornState.idle,
+        UnicornState.values,
+      );
+      unicorn.current = unicornState;
 
-      return GameWidget(
-        game: StoryGame(unicorn..current = UnicornState.idle),
-      );
-    },
-    info: '''
-      The UnicornComponent is a component that represents a unicorn.
-''',
-  ).add(
-    'roaming',
-    (context) {
-      final unicorn = context.listProperty<UnicornComponent>(
-        'Unicorn stage',
-        BabyUnicornComponent(),
-        [
-          BabyUnicornComponent(),
-          ChildUnicornComponent(),
-          TeenUnicornComponent(),
-          AdultUnicornComponent(),
-        ],
-      );
+      final game = context.storyGame(component: unicorn);
 
-      return GameWidget(
-        game: StoryGame(unicorn..current = UnicornState.roaming),
-      );
+      return GameWidget(game: game);
     },
-    info: '''
-      The UnicornComponent is a component that represents a unicorn.
-''',
+    info: 'The UnicornComponent is a component that represents a unicorn.',
   );
 }


### PR DESCRIPTION

## Description
Currently, the sandbox story for unicorns goes DEAD RED when the property panel is opened.

This fixes that and makes the unicorn story to keep the game instance across builds. 



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
