### PR TITLE
fix: run each preload phase in the next tick

### DIFF
--- a/lib/loading/cubit/preload/preload_cubit.dart
+++ b/lib/loading/cubit/preload/preload_cubit.dart
@@ -26,7 +26,7 @@ class PreloadCubit extends Cubit<PreloadState> {
       emit(state.onStartPhase(phase.label));
       // Throttle phases to take at least 1/5 seconds
       await Future.wait([
-        phase.start(),
+        Future.delayed(Duration.zero, phase.start),
         Future<void>.delayed(const Duration(milliseconds: 200)),
       ]);
       emit(state.onFinishPhase());

--- a/test/loading/cubit/preload/preload_cubit_test.dart
+++ b/test/loading/cubit/preload/preload_cubit_test.dart
@@ -36,6 +36,9 @@ void main() {
 
         final future = cubit.loadSequentially();
 
+        // Each phase is called in the next tick, so we need to settle first.
+        await tester.pumpAndSettle(const Duration(microseconds: 1));
+
         verify(
           () => images.loadAll(
             [


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fix a bug where the UI is not correctly updated because a "heaver" preload phase is blocking the thread and therefore the bloc stream can't give our UI the new state. Which in turn would not show a label update.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
