### PR TITLE
fix: adding or removing behaviors in the same update loop

### DIFF
--- a/lib/game/entities/unicorn/unicorn.dart
+++ b/lib/game/entities/unicorn/unicorn.dart
@@ -266,13 +266,13 @@ class Unicorn extends Entity with Steerable, HasGameRef<SeedGame> {
   }
 
   void _startMoving() {
-    if (!hasBehavior<WanderBehavior>()) {
-      add(_wanderBehavior);
+    if (!hasBehavior<WanderBehavior>() && !_wanderBehavior.isLoading) {
+      _wanderBehavior.addToParent(this);
     }
   }
 
   void _stopMoving() {
-    if (hasBehavior<WanderBehavior>()) {
+    if (hasBehavior<WanderBehavior>() || _wanderBehavior.isLoading) {
       _wanderBehavior.removeFromParent();
     }
   }

--- a/test/game/entities/unicorn/unicorn_test.dart
+++ b/test/game/entities/unicorn/unicorn_test.dart
@@ -100,6 +100,48 @@ void main() {
         },
       );
       flameTester.test(
+        'setting as walking in a sequence',
+        (game) async {
+          final unicorn = Unicorn(
+            position: Vector2.all(1),
+            onMountGauge: (gauge) {},
+            onUnmountGauge: (gauge) {},
+          );
+          await game.ready();
+          await game.background.ensureAdd(unicorn);
+
+          expect(unicorn.state, UnicornState.idle);
+
+          unicorn.setUnicornState(UnicornState.walking);
+          unicorn.setUnicornState(UnicornState.walking);
+
+          await game.ready();
+          expect(unicorn.hasBehavior<WanderBehavior>(), isTrue);
+          expect(unicorn.state, UnicornState.walking);
+        },
+      );
+      flameTester.test(
+        'setting as walking and then to idle in a sequence ',
+        (game) async {
+          final unicorn = Unicorn(
+            position: Vector2.all(1),
+            onMountGauge: (gauge) {},
+            onUnmountGauge: (gauge) {},
+          );
+          await game.ready();
+          await game.background.ensureAdd(unicorn);
+
+          expect(unicorn.state, UnicornState.idle);
+
+          unicorn.setUnicornState(UnicornState.walking);
+          unicorn.setUnicornState(UnicornState.idle);
+
+          await game.ready();
+          expect(unicorn.hasBehavior<WanderBehavior>(), isFalse);
+          expect(unicorn.state, UnicornState.idle);
+        },
+      );
+      flameTester.test(
         'setting to idle should stop moving',
         (game) async {
           final unicorn = Unicorn(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When adding or removing components In the same update loop, we have to check the components lifecycle state rather than their presence in the component tree. This happens because `add` will take effect on `Query` only yin the following update cycle.

Since `Timer` can tick multiple times in the same update cycle (if an update's `dt` is bigger than its `limit`), we may face this bug triggered the `MovingBehavior`.  Adding an extra check on `isLoading`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
